### PR TITLE
fix(ci): seed pip in tox-uv environments

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -36,5 +36,5 @@ jobs:
       - run: sudo apt-get install -y $(bindep -b)
         working-directory: ${{ inputs.repository }}
       - run: uv tool install tox --with tox-uv
-      - run: tox -e ${{ matrix.env }}
+      - run: tox -e ${{ matrix.env }} -x testenv.uv_seed=true
         working-directory: ${{ inputs.repository }}


### PR DESCRIPTION
## Summary
- enable tox-uv's `uv_seed` compatibility shim for reusable tox jobs
- keep using tox-uv while making legacy OpenStack `install_command = pip install ...` configs work

## Validation
- `nix-shell -p actionlint --run 'actionlint -ignore "SC2046" .github/workflows/tox.yml'`

Note: the ignored SC2046 warning is for the existing `apt-get install -y $(bindep -b)` package-list expansion.
