### PR TITLE
fix(ci): use virtualenv runner for tox

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -36,5 +36,5 @@ jobs:
       - run: sudo apt-get install -y $(bindep -b)
         working-directory: ${{ inputs.repository }}
       - run: uv tool install tox --with tox-uv
-      - run: tox -e ${{ matrix.env }} -x testenv.uv_seed=true
+      - run: tox --runner virtualenv -e ${{ matrix.env }}
         working-directory: ${{ inputs.repository }}


### PR DESCRIPTION
## Summary
- use tox's `virtualenv` runner for the reusable tox workflow
- keep installing tox with uv, but avoid tox-uv's uv-specific package install options for legacy OpenStack `install_command = pip install ...` configs

## Why
`uv_seed=true` fixes missing/forbidden pip during dependency installation, but tox-uv still passes `--reinstall` during package installation. Legacy tox configs forward that through `install_command = pip install {opts} {packages}`, and pip rejects `--reinstall`.

The virtualenv runner falls back to pip-compatible package install options such as `--force-reinstall --no-deps`.

## Validation
- `nix-shell -p actionlint --run 'actionlint -ignore "SC2046" .github/workflows/tox.yml'`
- local tox-uv package-install reproduction: default tox-uv runner failed with `no such option: --reinstall`; `tox --runner virtualenv -elegacy` passed
