### PR TITLE
fix(ci): install tox bindep test profile

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -33,7 +33,12 @@ jobs:
           ref: ${{ inputs.ref }}
       - run: uv tool install bindep
       - run: sudo apt-get update
-      - run: sudo apt-get install -y $(bindep -b)
+      - run: |
+          packages="$(bindep -b test "${{ matrix.env }}" || true)"
+          if [ -n "$packages" ]; then
+            sudo apt-get install -y $packages
+          fi
+          bindep -b test "${{ matrix.env }}"
         working-directory: ${{ inputs.repository }}
       - run: uv tool install tox --with tox-uv
       - run: tox --runner virtualenv -e ${{ matrix.env }}


### PR DESCRIPTION
## Summary
- install bindep packages with the OpenStack tox profiles: `test` plus the matrix env
- keep a final bindep check after apt installs missing packages

## Testing
- `nix-shell -p python313Packages.pyyaml --run 'python3 -c "import yaml; yaml.safe_load(open(\".github/workflows/tox.yml\")); print(\"ok\")"'`