### PR TITLE
fix(ci): skip bindep when requirements are absent

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -34,11 +34,13 @@ jobs:
       - run: uv tool install bindep
       - run: sudo apt-get update
       - run: |
-          packages="$(bindep -b test "${{ matrix.env }}" || true)"
-          if [ -n "$packages" ]; then
-            sudo apt-get install -y $packages
+          if [ -f bindep.txt ] || [ -f other-requirements.txt ]; then
+            packages="$(bindep -b test "${{ matrix.env }}" || true)"
+            if [ -n "$packages" ]; then
+              sudo apt-get install -y $packages
+            fi
+            bindep -b test "${{ matrix.env }}"
           fi
-          bindep -b test "${{ matrix.env }}"
         working-directory: ${{ inputs.repository }}
       - run: uv tool install tox --with tox-uv
       - run: tox --runner virtualenv -e ${{ matrix.env }}


### PR DESCRIPTION
## Summary
- skip bindep installation when the checked-out project has no `bindep.txt` or `other-requirements.txt`
- keep `test` plus the tox matrix env profile for projects that do declare bindep requirements

## Testing
- `nix-shell -p python313Packages.pyyaml --run 'python3 -c "import yaml; yaml.safe_load(open(\".github/workflows/tox.yml\")); print(\"ok\")"'`