### PR TITLE
Auto-detect versioned image metadata

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -75,7 +75,7 @@ runs:
           type=ref,event=pr,enable=${{ inputs.image-version == '' }}
           type=raw,value=${{ inputs.image-version }},enable=${{ inputs.image-version != '' && github.ref_name != github.event.repository.default_branch }}
           type=raw,value=main,enable=${{ inputs.image-version != '' && github.ref_name == github.event.repository.default_branch }}
-          type=match,pattern=stable/(.*),group=1,value={{branch}},enable=${{ inputs.image-version != '' }}
+          type=match,pattern=stable/(.*),group=1,value={{branch}},enable=${{ inputs.image-version != '' && startsWith(github.ref_name, 'stable/') }}
           type=raw,value=latest,enable=${{ inputs.image-version != '' && inputs.publish-latest == 'true' }}
           type=ref,event=pr,enable=${{ inputs.image-version != '' }}
 

--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -23,15 +23,6 @@ inputs:
     description: 'Save the image to the Depot ephemeral registry'
     required: false
     default: 'false'
-  image-version:
-    description: 'Artifact version used for standardized release tags'
-    required: false
-    default: ''
-  publish-latest:
-    description: 'Publish the latest tag when using a standardized image version'
-    required: false
-    default: 'false'
-
 outputs:
   imageid:
     description: 'Image ID'
@@ -55,6 +46,67 @@ outputs:
 runs:
   using: composite
   steps:
+    - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+      id: image-metadata
+      env:
+        IMAGE_NAME: ${{ inputs.image-name }}
+      with:
+        script: |
+          const versionArgument = `${process.env.IMAGE_NAME
+            .toUpperCase()
+            .replace(/[^A-Z0-9]/g, '_')}_VERSION`;
+
+          let version = '';
+          try {
+            const response = await github.rest.repos.getContent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              path: 'Dockerfile',
+              ref: context.sha,
+            });
+            if (!Array.isArray(response.data) && response.data.content) {
+              const dockerfile = Buffer.from(
+                response.data.content,
+                response.data.encoding,
+              ).toString();
+              const match = dockerfile.match(
+                new RegExp(`^ARG ${versionArgument}=(\\S+)$`, 'm'),
+              );
+              version = match?.[1] || '';
+            }
+          } catch (error) {
+            if (error.status !== 404) {
+              throw error;
+            }
+          }
+
+          let latestStable = '';
+          if (version) {
+            const branches = await github.paginate(
+              github.rest.repos.listBranches,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 100,
+              },
+            );
+            latestStable = branches
+              .map(({ name }) => {
+                const match = name.match(/^stable\/(\d{4})\.(\d+)$/);
+                return match
+                  ? { name, year: Number(match[1]), cycle: Number(match[2]) }
+                  : null;
+              })
+              .filter(Boolean)
+              .sort((a, b) => b.year - a.year || b.cycle - a.cycle)[0]?.name || '';
+          }
+
+          core.setOutput('version', version);
+          core.setOutput(
+            'publish-latest',
+            Boolean(latestStable && context.ref === `refs/heads/${latestStable}`),
+          );
+
     - uses: step-security/depot-setup-action@b4aca7ffc00ee3722a62991ae7a7f32f20ea225a # v1.7.1
 
     - uses: step-security/docker-login-action@164e21d7e52229904128e2f946001cb88278c33d # v4.2.0
@@ -68,12 +120,12 @@ runs:
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.image-name }}
         tags: |
-          type=raw,value=latest,enable=${{ (inputs.image-version == '' && github.ref_name == github.event.repository.default_branch) || inputs.publish-latest == 'true' }}
+          type=raw,value=latest,enable=${{ (steps.image-metadata.outputs.version == '' && github.ref_name == github.event.repository.default_branch) || steps.image-metadata.outputs.publish-latest == 'true' }}
           type=sha,prefix=
           type=ref,event=branch
           type=match,pattern=stable/(.*),group=1,value={{branch}}
           type=ref,event=pr
-          type=raw,value=${{ inputs.image-version }},enable=${{ inputs.image-version != '' && github.ref_name != github.event.repository.default_branch }}
+          type=raw,value=${{ steps.image-metadata.outputs.version }},enable=${{ steps.image-metadata.outputs.version != '' && github.ref_name != github.event.repository.default_branch }}
 
     - uses: depot/build-push-action@9785b135c3c76c33db102e45be96a25ab55cd507 # v1.16.2
       id: build

--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -23,15 +23,14 @@ inputs:
     description: 'Save the image to the Depot ephemeral registry'
     required: false
     default: 'false'
-  tag-rules:
-    description: 'docker/metadata-action tag rules'
+  image-version:
+    description: 'Artifact version used for standardized release tags'
     required: false
-    default: |
-      type=raw,value=latest,enable={{is_default_branch}}
-      type=sha,prefix=
-      type=ref,event=branch
-      type=match,pattern=stable/(.*),group=1,value={{branch}}
-      type=ref,event=pr
+    default: ''
+  publish-latest:
+    description: 'Publish the latest tag when using a standardized image version'
+    required: false
+    default: 'false'
 
 outputs:
   imageid:
@@ -68,7 +67,17 @@ runs:
       id: meta
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.image-name }}
-        tags: ${{ inputs.tag-rules }}
+        tags: |
+          type=raw,value=latest,enable=${{ inputs.image-version == '' && github.ref_name == github.event.repository.default_branch }}
+          type=sha,prefix=,enable=${{ inputs.image-version == '' }}
+          type=ref,event=branch,enable=${{ inputs.image-version == '' }}
+          type=match,pattern=stable/(.*),group=1,value={{branch}},enable=${{ inputs.image-version == '' }}
+          type=ref,event=pr,enable=${{ inputs.image-version == '' }}
+          type=raw,value=${{ inputs.image-version }},enable=${{ inputs.image-version != '' && github.ref_name != github.event.repository.default_branch }}
+          type=raw,value=main,enable=${{ inputs.image-version != '' && github.ref_name == github.event.repository.default_branch }}
+          type=match,pattern=stable/(.*),group=1,value={{branch}},enable=${{ inputs.image-version != '' }}
+          type=raw,value=latest,enable=${{ inputs.image-version != '' && inputs.publish-latest == 'true' }}
+          type=ref,event=pr,enable=${{ inputs.image-version != '' }}
 
     - uses: depot/build-push-action@9785b135c3c76c33db102e45be96a25ab55cd507 # v1.16.2
       id: build

--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -68,16 +68,12 @@ runs:
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.image-name }}
         tags: |
-          type=raw,value=latest,enable=${{ inputs.image-version == '' && github.ref_name == github.event.repository.default_branch }}
-          type=sha,prefix=,enable=${{ inputs.image-version == '' }}
-          type=ref,event=branch,enable=${{ inputs.image-version == '' }}
-          type=match,pattern=stable/(.*),group=1,value={{branch}},enable=${{ inputs.image-version == '' }}
-          type=ref,event=pr,enable=${{ inputs.image-version == '' }}
+          type=raw,value=latest,enable=${{ (inputs.image-version == '' && github.ref_name == github.event.repository.default_branch) || inputs.publish-latest == 'true' }}
+          type=sha,prefix=
+          type=ref,event=branch
+          type=match,pattern=stable/(.*),group=1,value={{branch}}
+          type=ref,event=pr
           type=raw,value=${{ inputs.image-version }},enable=${{ inputs.image-version != '' && github.ref_name != github.event.repository.default_branch }}
-          type=raw,value=main,enable=${{ inputs.image-version != '' && github.ref_name == github.event.repository.default_branch }}
-          type=match,pattern=stable/(.*),group=1,value={{branch}},enable=${{ inputs.image-version != '' && startsWith(github.ref_name, 'stable/') }}
-          type=raw,value=latest,enable=${{ inputs.image-version != '' && inputs.publish-latest == 'true' }}
-          type=ref,event=pr,enable=${{ inputs.image-version != '' }}
 
     - uses: depot/build-push-action@9785b135c3c76c33db102e45be96a25ab55cd507 # v1.16.2
       id: build

--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -23,6 +23,15 @@ inputs:
     description: 'Save the image to the Depot ephemeral registry'
     required: false
     default: 'false'
+  tag-rules:
+    description: 'docker/metadata-action tag rules'
+    required: false
+    default: |
+      type=raw,value=latest,enable={{is_default_branch}}
+      type=sha,prefix=
+      type=ref,event=branch
+      type=match,pattern=stable/(.*),group=1,value={{branch}}
+      type=ref,event=pr
 
 outputs:
   imageid:
@@ -59,12 +68,7 @@ runs:
       id: meta
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.image-name }}
-        tags: |
-          type=raw,value=latest,enable={{is_default_branch}}
-          type=sha,prefix=
-          type=ref,event=branch
-          type=match,pattern=stable/(.*),group=1,value={{branch}}
-          type=ref,event=pr
+        tags: ${{ inputs.tag-rules }}
 
     - uses: depot/build-push-action@9785b135c3c76c33db102e45be96a25ab55cd507 # v1.16.2
       id: build

--- a/default.json
+++ b/default.json
@@ -46,6 +46,15 @@
         "(?<depName>[a-zA-Z0-9][a-zA-Z0-9._-]*)==(?<currentValue>[0-9][^\\s\\\\]*)"
       ],
       "datasourceTemplate": "pypi"
+    },
+    {
+      "customType": "regex",
+      "description": "Update versioned Python images from Dockerfile build arguments",
+      "fileMatch": ["(^|/)Dockerfile$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+ARG [A-Z0-9_]+_VERSION=(?<currentValue>\\S+)"
+      ],
+      "versioningTemplate": "pep440"
     }
   ],
   "packageRules": [

--- a/default.json
+++ b/default.json
@@ -54,10 +54,18 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+ARG [A-Z0-9_]+_VERSION=(?<currentValue>\\S+)"
       ],
+      "depTypeTemplate": "versioned-image",
       "versioningTemplate": "pep440"
     }
   ],
   "packageRules": [
+    {
+      "description": "Keep versioned images on their current major release on stable branches",
+      "matchBaseBranches": ["/^stable/.*/"],
+      "matchDepTypes": ["versioned-image"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
     {
       "description": "Only allow digest updates for vexxhost images on stable branches",
       "matchBaseBranches": ["/^stable/.*/"],


### PR DESCRIPTION
## What changed

- detect versioned images automatically from a conventional Dockerfile argument such as `OCTAVIA_VERSION`
- add the tag-safe artifact version while preserving SHA, branch, release-line, and PR tags
- discover the newest numeric `stable/*` branch and assign `latest` to it
- preserve the existing default-branch `latest` behavior when no version argument is present
- teach the shared Renovate preset to update annotated version arguments while rejecting major updates on stable branches

## Why

Versioned image repositories should not duplicate tag policy or Renovate configuration on every branch. The shared action can derive the package-version argument from `image-name`, inspect the caller's Dockerfile, and apply the policy centrally.

## Compatibility

- existing callers without a matching version argument retain their current tags unchanged
- versioned callers retain legacy SHA, branch, release-line, and PR tags and gain the artifact-version tag
- only versioned default branches stop owning `latest`; it moves automatically to the newest numeric stable branch

## Validation

- `git diff --check`
- parsed the action YAML with `yq`
- syntax-checked the embedded GitHub script with Node.js
- parsed and validated the shared Renovate JSON
