### PR TITLE
Fix latest image tag ownership

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -59,6 +59,8 @@ runs:
       id: meta
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.image-name }}
+        flavor: |
+          latest=false
         tags: |
           type=raw,value=latest,enable={{is_default_branch}}
           type=sha,prefix=


### PR DESCRIPTION
## Summary

- disable docker/metadata-action's automatic `latest` flavor
- keep the existing explicit `latest` tag limited to the repository's default branch
- preserve all existing branch, stable-series, SHA, and pull-request tags

## Root cause

The `type=match` stable-series rule participates in docker/metadata-action's default `latest=auto` behavior. As a result, every `stable/*` build also publishes `latest`, even though the explicit raw `latest` rule is conditional on `{{is_default_branch}}`. Concurrent stable builds can therefore leave `latest` pointing at whichever branch finishes last.

Setting `flavor: latest=false` disables implicit generation. The explicit raw rule remains enabled for the default branch, making it the sole owner of `latest`.

## Validation

- `nix-shell -p yq-go --run 'yq e . .github/actions/build-image/action.yml > /dev/null'`
- `git diff --check`

Consumers pinning this action by commit SHA will need to update to this commit before the fix takes effect.
